### PR TITLE
Class attribute in row definition

### DIFF
--- a/modules/library-stk/region.xsl
+++ b/modules/library-stk/region.xsl
@@ -26,9 +26,9 @@
     </xsl:template>
     
     <xsl:template match="row" mode="stk:region.create">
-        <div class="row">
+        <div>
+            <xsl:attribute name="class" select="concat('row ', @class)" />
             <xsl:apply-templates select="group|region[@name = $stk:region.active-regions/name]" mode="stk:region.create"/>
-            
         </div>
     </xsl:template>
     


### PR DESCRIPTION
Lets you set a class attribute on rows in the layout definition of theme.xml.

Useful for styling a row containing multiple columns. For example adding a background color.

Example:

```
<layout name="sidebar">
    <row cols="12" class="content-container">
        <region name="r1-c1">
            <cols>8</cols>
        </region>
        <region name="r1-c2">
            <cols>4</cols>
        </region>
    </row>
</layout>
```
