### PR TITLE
Support loading responsive images with display: none

### DIFF
--- a/_public/library-stk/css/mixins.less
+++ b/_public/library-stk/css/mixins.less
@@ -81,3 +81,14 @@
     white-space: nowrap;
     overflow: hidden;
 }
+
+.clearfix() {
+    &:before,
+    &:after {
+        content: " ";
+        display: table;
+    }
+    &:after {
+        clear: both;
+    }
+}

--- a/_public/library-stk/js/stk.js
+++ b/_public/library-stk/js/stk.js
@@ -115,6 +115,8 @@ STK.responsive = {
     optimizeImages: function (callback) {
         $('img[data-srcset]').each(function () {
             var img = $(this);
+            // Either use the selector from data-scale-by or the image for scaling.
+            var scaleBy = (img.attr('data-scale-by')) ? $(img.data('scale-by')).first() : img;
             var srcset = img.data('srcset');
             if (typeof srcset === 'object') {
                 var sizes =[];
@@ -124,7 +126,7 @@ STK.responsive = {
                 sizes.sort(function (a, b) {
                     return a - b;
                 });
-                var width = Math.floor(img.width() * (window.devicePixelRatio || 1));
+                var width = Math.floor(scaleBy.width() * (window.devicePixelRatio || 1));
                 var srcIndex = getClosestHigherNum(width, sizes);
                 img.attr('src', srcset[srcIndex]);
             }

--- a/_public/theme-sample-site/css/responsive.less
+++ b/_public/theme-sample-site/css/responsive.less
@@ -15,7 +15,7 @@
 .loop-grid-span (@grid-columns);
 
 .row {
-	overflow: hidden;
+	.clearfix();
 }
 
 .group {

--- a/modules/library-stk/image.xsl
+++ b/modules/library-stk/image.xsl
@@ -35,6 +35,7 @@
         <xsl:param name="style" as="xs:string?"/>
         <xsl:param name="id" as="xs:string?"/>
         <xsl:param name="attr" as="xs:string*"/>
+        <xsl:param name="scale-by" as="''"/>
         
         <xsl:variable name="original-image-size" as="xs:integer*" select="stk:image.get-original-size($image)"/>
         
@@ -141,6 +142,9 @@
                        </xsl:if>
                        <xsl:attribute name="data-srcset" select="$data-srcset"/>
                        <xsl:attribute name="data-ar" select="$image-ar[1] div $image-ar[2]"/>
+                       <xsl:if test="$scale-by != ''">
+                           <xsl:attribute name="data-scale-by" select="$scale-by"/>
+                       </xsl:if>
                        <xsl:attribute name="class">
                            <xsl:text>js-img </xsl:text>
                            <xsl:value-of select="$size"/>

--- a/modules/library-stk/image.xsl
+++ b/modules/library-stk/image.xsl
@@ -35,7 +35,7 @@
         <xsl:param name="style" as="xs:string?"/>
         <xsl:param name="id" as="xs:string?"/>
         <xsl:param name="attr" as="xs:string*"/>
-        <xsl:param name="scale-by" as="''"/>
+        <xsl:param name="scale-by" select="''"/>
         
         <xsl:variable name="original-image-size" as="xs:integer*" select="stk:image.get-original-size($image)"/>
         


### PR DESCRIPTION
This fixes the issue with hidden images being loaded as the smallest possible size when using STK.responsive.optimizeImages();

It adds a parameter called "scale-by" to stk:image.create. It takes a jQuery selector. If "scale-by" is set, this will load the image not based on it's own size, but based on the size of the first element matched by the selector.

This is useful where you want responsive images to load while being hidden - for example when creating image carousels, because this would enable you to initiate the carousel before STK.responsive.optimizeImages() and thus preventing the page from jumping.
