### PR TITLE
Add support for anchor tags and get parameters

### DIFF
--- a/modules/library-stk/html.xsl
+++ b/modules/library-stk/html.xsl
@@ -200,7 +200,19 @@
     
     
     <xsl:template match="@href[parent::a]|@data[parent::object]|@src[parent::param]|@src[parent::video]|@src[parent::audio]|@src[parent::source]|@src[parent::track]" mode="html.process">
-        <xsl:attribute name="{name()}" select="stk:html.process-url(.)"/>
+       <xsl:attribute name="{name()}">
+            <xsl:choose>
+                <xsl:when test="contains(., '#')">
+                    <xsl:value-of select="concat(stk:html.process-url(substring-before(., '#')), '#', substring-after(., '#'))"/>
+                </xsl:when>
+                <xsl:when test="contains(., '?')">
+                    <xsl:value-of select="concat(stk:html.process-url(substring-before(., '?')), '?', substring-after(., '?'))"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="stk:html.process-url(.)"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:attribute>
     </xsl:template>
     
     <xsl:template match="iframe[contains(@src, 'youtube')]" mode="html.process">


### PR DESCRIPTION
This patch fixes a problem with the HTML link parser, which doesn't handle anchor tags (or get parameters) correctly in the case of content linking (``page://``, ``content://`` etc).

Fixes #54